### PR TITLE
Fixed bug in command line options.

### DIFF
--- a/bismark_wrapper/bismark_methylation_extractor.xml
+++ b/bismark_wrapper/bismark_methylation_extractor.xml
@@ -14,7 +14,7 @@
 
         --infile $input
 
-        #--bismark_path \$SCRIPT_PATH
+        --bismark_path \$SCRIPT_PATH
 
         #if $singlePaired.sPaired == "single":
             --single-end


### PR DESCRIPTION
Eliminated the # symbol in front of --bismark_path which messed up the options passed on the command line to bismark_methylation_extractor.